### PR TITLE
max_inners feature support to reduce full scans on large datasets

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -23,6 +23,7 @@ FuzzySearch.defaultOptions =
     thresh_include: 2.0,              // To be a candidate, score of item must be at least this
     thresh_relative_to_best: 0.5,     // and be at least this fraction of the best score
     field_good_enough: 20,            // If a field have this score, stop searching other fields. (field score is before item related bonus)
+    max_inners: null,                  // With large datasets, abandon searches early when there area lot of matches ("high positive count mitigation", see https://github.com/jeancroy/fuzz-aldrin-plus#high-positive-count-mitigation for more details)
 
     //
     //  Scoring, bonus

--- a/src/search.js
+++ b/src/search.js
@@ -75,6 +75,7 @@ extend(FuzzySearch.prototype, /** @lends {FuzzySearch.prototype} */ {
         var opt_bpd = options.bonus_position_decay;
         var opt_fge = options.field_good_enough;
         var opt_trb = options.thresh_relative_to_best;
+        var opt_max_inners = options.max_inners;
         var opt_score_tok = options.score_per_token;
         var opt_round = options.score_round;
         var thresh_include = options.thresh_include;
@@ -164,8 +165,10 @@ extend(FuzzySearch.prototype, /** @lends {FuzzySearch.prototype} */ {
             //candidate for best result ? push to list
             //
 
-            if (item_score > thresh_include) {
+            var max_inners_reached = (opt_max_inners && opt_max_inners <= results.length);
+            if (max_inners_reached) break;
 
+            if (item_score > thresh_include) {
                 item_score = Math.round(item_score / opt_round) * opt_round;
 
                 results.push(new SearchResult(
@@ -176,7 +179,6 @@ extend(FuzzySearch.prototype, /** @lends {FuzzySearch.prototype} */ {
                     matched_node_index,
                     item_fields[0][0].join(" ")
                 ));
-
             }
 
         }


### PR DESCRIPTION
**Note: WIP, not ready for review/merging. Just pushing up to GitHub so I don't forget about it on my local.**

See https://github.com/jeancroy/FuzzySearch/issues/7

Follow the 'high positive count mitigation' technique from
https://github.com/jeancroy/fuzz-aldrin-plus#high-positive-count-mitigation

Note: This commit doesn't include the dist/ files, but they still
need to be added.