### PR TITLE
Fix Uncaught (in promise) TypeError: Cannot read properties of undefi…

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -178,7 +178,7 @@ extend(FuzzySearch.prototype, /** @lends {FuzzySearch.prototype} */ {
                     item_score,
                     matched_field_index,
                     matched_node_index,
-                    item_fields[0][0].join(" ")
+                    (item_fields[0][0] || []).join(" ")
                 ));
 
             }


### PR DESCRIPTION
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'join')
    at FuzzySearch._searchIndex (FuzzySearch.min.js:1539:39)
    at FuzzySearch.search (FuzzySearch.min.js:1394:35)

Data at hand when it goes KABOOM below

Unfortunately, I have no clue what this code does and why, I just figured this fixes it

```
[
    [],
    [],
    [
        [
            "biletbank",
            "[internal",
            "use",
            "only]"
        ]
    ]
]
```